### PR TITLE
docs: fix order of practices articles in sidebar

### DIFF
--- a/docs/Practices/how-we-engineer.md
+++ b/docs/Practices/how-we-engineer.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Prenda: Engineering Team Principles

--- a/docs/Practices/npm.md
+++ b/docs/Practices/npm.md
@@ -1,5 +1,8 @@
-# NPM best practices
+---
+sidebar_position: 2
+---
 
+# NPM best practices
 
 #### TLDR
 Always run `nvm use` before starting a project. Use `npm i` for keeping installed packages up-to-date in everyday development. Pay attention to package lock file updates from `npm i` and open isolated pull requests fo them. Use `npm ci` when you want to mimic automated jobs (like CI) or install packages exactly as the lock file describes.


### PR DESCRIPTION
Makes "How We Engineer" first (previously second) and NPM second (previously unordered, appearing last).