### PR TITLE
Add arch board docs and template

### DIFF
--- a/docs/ArchitectureBoard/architecture-impact-brief-template.md
+++ b/docs/ArchitectureBoard/architecture-impact-brief-template.md
@@ -1,0 +1,42 @@
+---
+sidebar_label: AIB Template
+---
+
+# Architecture Impact Brief
+
+
+# Purpose
+
+When a project is prioritized by the Product Steering Committee for execution it must be assessed by its lead engineer in collaboration with their team and product manager for its impact on enterprise system and data architecture. Should a [reasonable threshold](https://docs.google.com/document/u/0/d/167U8vC_FWK6vLUbhuxGzCcUmXyo5jcKqtPg3UcB0QEg/edit) for formal review by the Architecture Board be met, the information requested in this document must be provided (in any format preferred and adequate for communicating the information) and scheduled for an architecture review. 
+
+
+# [Project Title]
+
+
+## [Submission Date]
+
+
+# Problem Statement
+
+[What problem(s) are being addressed by this project? Please explain the problem and include its existing effects on the overall system and any users. Describe the root cause of the problem in as much detail as possible.]
+
+
+# Proposed Solution
+
+[Describe the solution with emphasis on the application and data architectural changes being proposed. How will these changes address the problem? What are the potential benefits of the changes? (Scalability, security, improved performance, reduction of user friction, etc.)]
+
+
+# Implementation Plan
+
+[Please provide a high-level description of the steps required to implement the proposed changes. If other teams or domains are affected please include a discussion of the proposed communication and collaboration strategy.]
+
+
+# Impact Analysis
+
+[Describe the impact of the proposed changes on existing systems, applications, designs, components, and integrations. What are the risks associated with the changes? How will they be mitigated? What other teams will be affected by the changes?] 
+
+[Please include details related to applications and data stores involved (Hub, MongoDB, Prenda World, etc.), and data flows affected. List the API endpoints to be added/deleted/modified, along with a thorough inventory of other applications and processes that integrate with them.]
+
+
+
+[Link to Google Doc Template](https://docs.google.com/document/d/1j5yXUB9iWru07ExvbxbQjj6y1qSfIfh_kJ8qH42ojqE/edit#heading=h.2sgh0x4lz5s)

--- a/docs/ArchitectureBoard/architecture-impact-briefs.md
+++ b/docs/ArchitectureBoard/architecture-impact-briefs.md
@@ -1,0 +1,7 @@
+---
+sidebar_label: Submitted AIBs
+---
+
+# Architectural Impact Briefs
+
+1. [School Operations Model Proposal](https://docs.google.com/document/d/18RrU_96OKlnVBkgGvZ3bCUQxPlNNEQBNS-x44biPY4U)

--- a/docs/ArchitectureBoard/index.md
+++ b/docs/ArchitectureBoard/index.md
@@ -1,0 +1,49 @@
+# Architecture Board
+
+
+## Mandate 
+
+Prenda’s Architecture Board shall be assembled to manage the technical and data architecture of Prenda’s systems to enable the success and ensure the sustainability of Prenda’s strategic business objectives.
+
+
+## Composition
+
+The Board is composed of the Head of Technology, Engineering Team Leads, and at least one Engineer (with a preference for one engineer from each execution team), and shall extend to include other subject matter experts (e.g. Data Science, Tech Ops) according to the domain of the project being reviewed.
+
+Tasked with managing Prenda’s system and data architecture and assuring long-term health and sustainability, Board members must assess proposed technical projects in the context of their impact on system and data architecture. 
+
+
+## Functions and Processes
+
+The Board holds ad-hoc meetings to review newly submitted Architecture Impact Briefs (AIB) in a timely manner and to review the progress of ongoing architecture impacting execution team projects. 
+
+The Architecture Review Process includes assessment of:
+
+
+
+* Written Architecture Impact Brief 
+* Alignment with company strategic objectives
+* Effect on technical debt
+* Industry accepted engineering best practices
+
+
+## Presentation to Architecture Board
+
+When a project [prioritized by the Product Steering Committee for execution](https://app.asana.com/0/1202607194020840/list) is identified to have system or data architectural modifying components, an [Architecture Impact Brief (AIB)](https://docs.google.com/document/u/0/d/1j5yXUB9iWru07ExvbxbQjj6y1qSfIfh_kJ8qH42ojqE/edit) must be prepared and submitted for review by the Architecture Board.
+
+The project’s lead engineer, in collaboration with their execution team and Product Manager, is responsible for determining if the threshold for AIB submission is met. Some criteria for making this determination are:
+
+
+
+* Substantial mutations to data and/or data structure
+* Changes to direction or nature of data flows
+* Application architecture changes
+* Changes that affect a larger domain
+* Substantial refactors that involve a large portion of the codebase
+* Changes to an unversioned API endpoint
+
+Architecture Impact Briefs must include a project outline and summary, in addition to a  detailed inter- and intra-system impact analysis, calling out pertinent integrations, and detailing any new or modified data standards or conventions.
+
+AIBs will be reviewed by the Board, including subject matter experts as appropriate for context, and a meeting will be scheduled for presentation of the AIB by its author with any key individuals and supporting material as appropriate.
+
+The Board may suggest modifications to the AIBs where appropriate or ask for resubmission for a new review.  Reasonable alignment with the above listed criteria as determined by unanimous decision of all Board members in attendance is required for project execution to move forward.


### PR DESCRIPTION
Adding:
Architecture Board Folder
  * converted board purpose doc
  * converted template (and linked to google doc template for flexibility)
  * created list of submitted AIB's