### PR TITLE
Event Storming to Introduce DDD

### DIFF
--- a/docs/Practices/hub/learning.md
+++ b/docs/Practices/hub/learning.md
@@ -64,8 +64,9 @@ The following are simply links to [useful abstractions](../../glossary.md#useful
   > [We tend to violate monolith architecture by not respecting modules. Breaking them into services makes it harder to do so.](https://youtu.be/GBTdnfD6s5Q?t=1209) *3 min watch - just the Organization and teams section*
 
 ## Domain Driven Design
-- [Is Domain Driven Design Overrated?](https://www.youtube.com/watch?v=cTtO0oFohMY&ab_channel=iSAQB) *51 min watch*
 - [Domain Driven Design Hexagon](https://github.com/Sairyss/domain-driven-hexagon) *30 min read (reference material)*
+- [Using Event Storming to Introduce Domain Driven Design](https://philippe.bourgau.net/how-to-use-event-storming-to-introduce-domain-driven-design/)
+- [Is Domain Driven Design Overrated?](https://www.youtube.com/watch?v=cTtO0oFohMY&ab_channel=iSAQB) *51 min watch*
 
 ## Repository Pattern
 - [The Repository Pattern explained for EVERYONE (with Code Examples)](https://www.youtube.com/watch?v=Wiy54682d1w) *14 min watch*


### PR DESCRIPTION
Really good resource on Event Storming as an Introduction to DDD.

A snippet from the article matching my own experiences with orgs that are fully bought into DDD.

_I still remember the first project where we tried to follow the DDD principles. We were working in a bank, and writing a connector to an electronic broker. For 2 days following the deployment of the first version of our system, we heard nothing about it. This was quite unusual. The broker finally called us to say there was a bug in the way we were handling one message. We did not open the debugger. We only checked our logs. This was enough to explain which business rules where used, and that we thought we were right. 2 more days later, they admitted the bug was on their side._