### PR TITLE
Auth0: custom claim convention

### DIFF
--- a/docs/Practices/auth0.md
+++ b/docs/Practices/auth0.md
@@ -1,0 +1,2 @@
+## Conventions
+- Custom claims should be prefixed with `prenda_dev`. [Example in initial PR documenting implementation of this.](https://github.com/prenda-school/prendaworld/pull/5035)


### PR DESCRIPTION
Documenting the custom claim convention for auth0 - driven by [this PR](https://github.com/prenda-school/prendaworld/pull/5035).